### PR TITLE
Improve error handling

### DIFF
--- a/lib/poison.ex
+++ b/lib/poison.ex
@@ -3,12 +3,12 @@ defmodule Poison do
   alias Poison.Decode
   alias Poison.Parser
 
-  @spec encode(Encoder.t) :: { :ok, String.t } | { :error, any }
+  @spec encode(Encoder.t) :: { :ok, String.t } | { :error, { :invalid, any } }
   def encode(value, options \\ []) do
     { :ok, encode!(value, options) }
   rescue
-    exception ->
-      { :error, Exception.message(exception) }
+    exception in [Poison.EncodeError] ->
+      { :error, { :invalid,  exception.value } }
   end
 
   @spec encode(Encoder.t) :: String.t | no_return
@@ -17,7 +17,7 @@ defmodule Poison do
   end
 
   @spec decode(String.t) :: { :ok, Parser.t } | { :error, :invalid }
-    | { :error, :invalid, String.t }
+    | { :error, { :invalid, String.t } }
   def decode(string, options \\ []) do
     case Parser.parse(string, options) do
       { :ok, value } -> { :ok, Decode.decode(value, options) }

--- a/lib/poison/parser.ex
+++ b/lib/poison/parser.ex
@@ -28,7 +28,7 @@ defmodule Poison.Parser do
   @type t :: nil | true | false | list | float | integer | String.t | Map.t
 
   @spec parse(String.t, Keyword.t) :: {:ok, t} | {:error, :invalid}
-    | {:error, :invalid, String.t}
+    | {:error, {:invalid, String.t}}
   def parse(string, options \\ []) when is_binary(string) do
     {value, rest} = value(skip_whitespace(string), options[:keys])
     case skip_whitespace(rest) do
@@ -39,7 +39,7 @@ defmodule Poison.Parser do
     :invalid ->
       {:error, :invalid}
     {:invalid, token} ->
-      {:error, :invalid, token}
+      {:error, {:invalid, token}}
   end
 
   @spec parse!(String.t, Keyword.t) :: t | no_return
@@ -49,7 +49,7 @@ defmodule Poison.Parser do
         value
       {:error, :invalid} ->
         raise SyntaxError
-      {:error, :invalid, token} ->
+      {:error, {:invalid, token}} ->
         raise SyntaxError, token: token
     end
   end


### PR DESCRIPTION
`Posion.encode/2` currently rescues all exceptions. This means that it can catch "code bugs" when we only want it to catch "data bugs". Therefore it should only rescue encode errors.

The situation was also awkward because the errors returned could not easily be pattern matched on because the error information was a string. Including a string in this way is only useful if the string is going to be displayed to an end-user. It is likely that a custom error would be shown - that did not include the string in the error tuple. The errors now return a usable type that can be pattern matched on if required.

I have made the error returns consistent. This means a slightly different return for `Poison.decode/2`. I did this because it is awkward to have an error tuple that can be contain 2 or 3 elements.

``` elixir
case Posion.decode(data) do
  {:ok, term} -> do_stuff(term)
  {:error, _} -> send_error()
end
```
