### PR TITLE
Add VERSION file to hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Poison.Mixfile do
   end
 
   defp package do
-    [files: ~w(lib mix.exs README.md LICENSE UNLICENSE),
+    [files: ~w(lib mix.exs README.md LICENSE UNLICENSE VERSION),
      contributors: ["Devin Torres"],
      licenses: ["Unlicense"],
      links: %{"GitHub" => "https://github.com/devinus/poison"}]


### PR DESCRIPTION
Because otherwise reading the `VERSION` file will obviously fail. Right now the package on hex can't be built.
