### PR TITLE
Add Poison.encode_to_iodata(!)/2

### DIFF
--- a/lib/poison.ex
+++ b/lib/poison.ex
@@ -6,10 +6,8 @@ defmodule Poison do
   @doc """
   Encode a value to JSON.
 
-  iex> Poison.encode([1, 2, 3])
-  {:ok, "[1,2,3]"}
-  iex> Poison.encode([1, 2, 3], iodata: true)
-  {:ok, [91, "1", [44, "2", 44, "3"], 93]}
+      iex> Poison.encode([1, 2, 3])
+      {:ok, "[1,2,3]"}
   """
   @spec encode(Encoder.t, Keyword.t) :: {:ok, iodata} | {:ok, String.t}
     | {:error, {:invalid, any}}
@@ -21,12 +19,21 @@ defmodule Poison do
   end
 
   @doc """
+  Encode a value to JSON as iodata.
+
+      iex> Poison.encode_to_iodata([1, 2, 3])
+      {:ok, [91, "1", [44, "2", 44, "3"], 93]}
+  """
+  @spec encode_to_iodata(Encoder.t, Keyword.t) :: {:ok, iodata} | {:error, {:invalid, any}}
+  def encode_to_iodata(value, options \\ []) do
+    encode(value, [iodata: true] ++ options)
+  end
+
+  @doc """
   Encode a value to JSON, raises an exception on error.
 
-  iex> Poison.encode!([1, 2, 3])
-  "[1,2,3]"
-  iex> Poison.encode!([1, 2, 3], iodata: true)
-  [91, "1", [44, "2", 44, "3"], 93]
+      iex> Poison.encode!([1, 2, 3])
+      "[1,2,3]"
   """
   @spec encode!(Encoder.t, Keyword.t) :: iodata | no_return
   def encode!(value, options \\ []) do
@@ -39,10 +46,21 @@ defmodule Poison do
   end
 
   @doc """
+  Encode a value to JSON as iodata, raises an exception on error.
+
+      iex> Poison.encode_to_iodata!([1, 2, 3])
+      [91, "1", [44, "2", 44, "3"], 93]
+  """
+  @spec encode_to_iodata!(Encoder.t, Keyword.t) :: iodata | no_return
+  def encode_to_iodata!(value, options \\ []) do
+    encode!(value, [iodata: true] ++ options)
+  end
+
+  @doc """
   Decode JSON to a value.
 
-  iex> Poison.decode("[1,2,3]")
-  {:ok, [1, 2, 3]}
+      iex> Poison.decode("[1,2,3]")
+      {:ok, [1, 2, 3]}
   """
   @spec decode(iodata, Keyword.t) :: {:ok, Parser.t} | {:error, :invalid}
     | {:error, {:invalid, String.t}}
@@ -56,8 +74,8 @@ defmodule Poison do
   @doc """
   Decode JSON to a value, raises an exception on error.
 
-  iex> Poison.decode!("[1,2,3]")
-  [1, 2, 3]
+      iex> Poison.decode!("[1,2,3]")
+      [1, 2, 3]
   """
   @spec decode!(iodata, Keyword.t) :: Parser.t | no_return
   def decode!(iodata, options \\ []) do


### PR DESCRIPTION
Having an explicit function plays nicer with dialyzer
and makes Poison simpler to use as callbacks.

Ideally we would deprecate the :iodata option in
encode and titghen its typespecs but I haven't done
so in this commit in order to keep backwards
compatibility.

Pleeeeeease merge this and release 1.3. It would help a lot
in Phoenix too.
