### PR TITLE
Relax elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Poison.Mixfile do
   def project do
     [app: :poison,
      version: @version,
-     elixir: "~> 1.0.0",
+     elixir: "~> 1.0",
      description: "An experimental Elixir JSON library",
      deps: deps,
      package: package]


### PR DESCRIPTION
Poison currently requires Elixir version `~> 1.0.0`, which means it will give a warning message when running on any later minor version than `1.0.x`.

Since Elixir will follow semantic versioning, as stated in the [v1.0.0 release post](http://elixir-lang.org/blog/2014/09/18/elixir-v1-0-0-released/), I don't see any danger in doing this small change.