### PR TITLE
Fix decoding into structs w/ default values

### DIFF
--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -4,7 +4,7 @@ defmodule Posion.DecoderTest do
   import Poison.Decode
 
   defmodule Person do
-    defstruct [:name, :age]
+    defstruct [:name, age: 42]
   end
 
   defimpl Poison.Decoder, for: Person do
@@ -53,4 +53,15 @@ defmodule Posion.DecoderTest do
     person = %{"name" => "Devin Torres", "age" => 27, "dob" => "1987-01-29"}
     assert decode(person, as: Person) == "Devin Torres (27)"
   end
+
+  test "decoding into structs with default values" do
+    person = %{"name" => "Devin Torres"}
+    assert decode(person, as: Person) == "Devin Torres (42)"
+  end
+
+  test "decoding into structs with nil overriding defaults" do
+    person = %{"name" => "Devin Torres", "age" => nil}
+    assert decode(person, as: Person) == "Devin Torres ()"
+  end
+
 end


### PR DESCRIPTION
This PR fixes `Poison.Decode.transform_struct/4` to only set the keys included in the `value` which is being decoded. This allows a struct to be created with the default values for missing keys, rather than setting all missing keys to `nil`.

The test case probably explains this better than I can.