### PR TITLE
Parse should not raise an ArgumentError

### DIFF
--- a/lib/poison/parser.ex
+++ b/lib/poison/parser.ex
@@ -38,6 +38,8 @@ defmodule Poison.Parser do
       "" -> {:ok, value}
       other -> syntax_error(other)
     end
+  rescue
+    e in ArgumentError -> {:error, :argument}
   catch
     :invalid ->
       {:error, :invalid}
@@ -52,6 +54,8 @@ defmodule Poison.Parser do
         value
       {:error, :invalid} ->
         raise SyntaxError
+      {:error, :argument} ->
+        raise ArgumentError
       {:error, {:invalid, token}} ->
         raise SyntaxError, token: token
     end

--- a/test/poison/parser_test.exs
+++ b/test/poison/parser_test.exs
@@ -93,4 +93,14 @@ defmodule Poison.ParserTest do
     assert parse!(~s({"foo": "bar"}), keys: :atoms) == %{foo: "bar"}
     assert parse!(~s({"foo": "bar"}), keys: :atoms!) == %{foo: "bar"}
   end
+  
+  test "argument errors" do
+    assert parse(1) == {:error, :argument}
+    assert parse(1.0) == {:error, :argument}
+    assert parse(true) == {:error, :argument}
+    assert parse(:hello) == {:error, :argument}
+    assert parse(%{}) == {:error, :argument}
+    assert parse({}) == {:error, :argument}
+    assert parse(&(&1)) == {:error, :argument}
+  end
 end


### PR DESCRIPTION
IO.iodata_to_binary used in Parse will raise an error if the input is
not iodata, such as if we try to call Poison.decode(:hello). If an
error is raised, it will now be rescued and an {:error, :argument}
tuple will be returned instead. Parse! will raise an ArgumentError as
expected.