### PR TITLE
Adding (crude) pretty print functionality

### DIFF
--- a/bench/encoder_bench.exs
+++ b/bench/encoder_bench.exs
@@ -6,6 +6,10 @@ defmodule EncoderBench do
     Poison.encode!(list)
   end
 
+  bench "lists (Poison (pretty))", [list: gen_list] do
+    Poison.encode!(list, [pretty: true])
+  end
+
   bench "lists (jiffy)", [list: gen_list] do
     :jiffy.encode(list)
   end
@@ -21,6 +25,10 @@ defmodule EncoderBench do
   # Maps
   bench "maps (Poison)", [map: gen_map] do
     Poison.encode!(map)
+  end
+
+  bench "maps (Poison (pretty))", [map: gen_map] do
+    Poison.encode!(map, [pretty: true])
   end
 
   bench "maps (jiffy)", [map: gen_map] do
@@ -71,6 +79,10 @@ defmodule EncoderBench do
 
   bench "Poison", [data: gen_data] do
     Poison.encode!(data)
+  end
+
+  bench "Poison (pretty)", [data: gen_data] do
+    Poison.encode!(data, [pretty: true])
   end
 
   bench "jiffy", [data: gen_data] do

--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -180,7 +180,7 @@ defimpl Poison.Encoder, for: Map do
     prev_indent = Poison.Style.prev(style)
     next_options = Keyword.put(options, :pretty, Poison.Style.incr(style, current_indent))
 
-    fun = &[',\n', current_indent, Encoder.BitString.encode(encode_name(&1), next_options), ?:,
+    fun = &[',\n', current_indent, Encoder.BitString.encode(encode_name(&1), next_options), ?:, ? ,
                 Encoder.encode(:maps.get(&1, map), next_options ) | &2]
     [?{, ?\n, tl(:lists.foldl(fun, [], :maps.keys(map))), ?\n, prev_indent, ?}]
   end

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -39,7 +39,7 @@ defmodule Poison.EncoderTest do
   end
 
   test "Map (pretty)" do
-    assert to_json(%{foo: %{bar: "baz"}}, pretty: true) == ~s({\n  \"foo\":{\n    \"bar\":"baz"\n  }\n})
+    assert to_json(%{foo: %{bar: "baz"}}, pretty: true) == ~s({\n  \"foo\": {\n    \"bar\": "baz"\n  }\n})
   end
 
   test "List" do

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -38,9 +38,17 @@ defmodule Poison.EncoderTest do
     assert to_json(%{"foo" => "bar"})  == ~s({"foo":"bar"})
   end
 
+  test "Map (pretty)" do
+    assert to_json(%{foo: %{bar: "baz"}}, pretty: true) == ~s({\n  \"foo\":{\n    \"bar\":"baz"\n  }\n})
+  end
+
   test "List" do
     assert to_json([]) == "[]"
     assert to_json([1, 2, 3]) == "[1,2,3]"
+  end
+
+  test "List (pretty)" do
+    assert to_json([1, 2, 3], pretty: true) == "[\n  1,\n  2,\n  3\n]"
   end
 
   test "Range" do


### PR DESCRIPTION
I added a `pretty: true` option to `encode()` that will indent map and list values.
The indentation level is currently fixed to 2 spaces. Can ofc be a customizable option as well,
just want to know if this is even something that will be considered.

Also pretty sure that someone will know how to make this go faster.