### PR TITLE
Implements support for Decimal

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -173,6 +173,12 @@ defimpl Poison.Encoder, for: Integer do
   end
 end
 
+defimpl Poison.Encoder, for: Decimal do
+  def encode(decimal, _options) do
+    Decimal.to_string(decimal)
+  end
+end
+
 defimpl Poison.Encoder, for: Float do
   def encode(float, _options) do
     :io_lib_format.fwrite_g(float)

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,8 @@ defmodule Poison.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:earmark, "~> 0.1", only: :docs},
+    [{:decimal,   "~> 1.1"},
+     {:earmark, "~> 0.1", only: :docs},
      {:ex_doc, "~> 0.7", only: :docs},
      {:jiffy, github: "davisp/jiffy", only: :bench},
      {:exjsx, github: "talentdeficit/exjsx", only: :bench},

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -19,6 +19,13 @@ defmodule Poison.EncoderTest do
     assert to_json(9.9e100) == "9.9e100"
   end
 
+  test "Decimal" do
+    Decimal.with_context(%Decimal.Context{precision: 36, rounding: :floor}, fn ->
+      assert to_json(Decimal.new("1234.56789")) == "1234.56789"
+      assert to_json(Decimal.div(Decimal.new("123456789123489123456789"), Decimal.new("1000"))) == "123456789123489123456.789"
+    end)
+  end
+
   test "BitString" do
     assert to_json("hello world") == ~s("hello world")
     assert to_json("hello\nworld") == ~s("hello\\nworld")


### PR DESCRIPTION
Ok, this might be a bit controversial, but I'm creating this pull request anyway to start the discussion.

Context: I am building an Elixir library that interfaces with Bitcoin's JSON-RPC API. They work with numbers, and have written their own custom JSON parser that parses the numbers with fixed precision. Erlang and Elixir don't have fixed precision, so we're doomed to either use floating points or integers.

In my library, I'm using http://github.com/ericmj/decimal to expose this number to the user. However, this only works when parsing JSON: if I want to generate JSON to send back to the server (for example, when sending a payment) I need a safe way to generate JSON. 

Decimal's library provides a `to_string/1` function, and this patch makes use of this function in the encoder to generate valid JSON for arbitrary precision decimal numbers.

It is worth pointing out that Elixir's PostgreSQL library, postgrex, also uses this same Decimal library to represent numbers.