### PR TITLE
escape unit separator (ascii 31)

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -92,6 +92,10 @@ defimpl Poison.Encoder, for: BitString do
     end
   end
 
+  defp escape(<<31>> <> rest, mode) do
+    ["\\" <> <<31>> | escape(rest, mode)]
+  end
+
   # http://en.wikipedia.org/wiki/Unicode_control_characters
   defp escape(<<char>> <> rest, mode) when char < 0x1F or char == 0x7F do
     [seq(char) | escape(rest, mode)]

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -30,6 +30,7 @@ defmodule Poison.EncoderTest do
     assert to_json("𝄞", escape: :unicode) == ~s("\\uD834\\uDD1E")
     assert to_json("\x{2028}\x{2029}", escape: :javascript) == ~s("\\u2028\\u2029")
     assert to_json("áéíóúàèìòùâêîôûãẽĩõũ") == ~s("áéíóúàèìòùâêîôûãẽĩõũ")
+    assert to_json(<<31>>) == ~s("\\\x1f")
   end
 
   test "Map" do


### PR DESCRIPTION
i ran into this when encoding the response of an irc server and sending it to my javascript frontend. if not escaped, the resulting json can't be decoded by firefox and chrome.
i suspect that this might not be the best way to fix it. i'll happily take your guidance to a better approach.