### PR TITLE
[WIP] Ability to transform the keys

### DIFF
--- a/lib/poison/transformer.ex
+++ b/lib/poison/transformer.ex
@@ -1,0 +1,28 @@
+defmodule Poison.Transform do
+  @doc "Transform an object key"
+
+  @callback transform(String.t) :: String.t
+
+  # Identity fn is the default
+  # However a macro should be used to compile the optional transformer in
+  def transform(string) do
+    string
+  end
+end
+
+defmodule Poison.CamelCase do
+  @behaviour Poison.Transform
+
+  def transform(string) do
+    [h|t] = string |> Macro.camelize |> String.codepoints
+    String.downcase(h) <> to_string(t)
+  end
+end
+
+defmodule Poison.SnakeCase do
+  @behaviour Poison.Transform
+
+  def transform(string) do
+    Macro.underscore(string)
+  end
+end

--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -77,4 +77,9 @@ defmodule Poison.DecoderTest do
     address = %{"street" => "1 Main St.", "city" => "Austin", "state" => "TX", "zip" => "78701"}
     assert decode(address, as: %Address{}) == "1 Main St., Austin, TX  78701"
   end
+
+  # test "decoding map with key transform and string keys" do
+  #   person = %{"fooBar" => "Devin Torres"}
+  #   assert decode(person, key_transformer: Poison.SnakeCase) == %{foo_bar: "Devin Torres"}
+  # end
 end

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -46,6 +46,16 @@ defmodule Poison.EncoderTest do
       }
     }\
     """
+    assert to_json(%{foo_bar: %{bar_baz_quux: %{_baz_: "baz"}}}, key_transformer: Poison.CamelCase) == ~s({"fooBar":{"barBazQuux":{"baz":"baz"}}})
+    assert to_json(%{foo_bar: %{bar_baz_quux: %{_baz_: "baz"}}}, pretty: true, key_transformer: Poison.CamelCase) == """
+    {
+      "fooBar": {
+        "barBazQuux": {
+          "baz": "baz"
+        }
+      }
+    }\
+    """
   end
 
   test "List" do

--- a/test/poison/parser_test.exs
+++ b/test/poison/parser_test.exs
@@ -63,6 +63,17 @@ defmodule Poison.ParserTest do
     assert parse!(~s({"foo": {"bar": "baz"}})) == expected
   end
 
+  test "objects with transform" do
+    expected = %{"foo_bar" => "bazQuux"}
+    assert snakecase(~s({"fooBar": "bazQuux"})) == expected
+
+    expected = %{"foo_a" => "bar", "baz_a" => "quux"}
+    assert snakecase(~s({"fooA": "bar", "bazA": "quux"})) == expected
+
+    expected = %{"foo_bar" => %{"bar_quux" => "baz"}}
+    assert snakecase(~s({"fooBar": {"barQuux": "baz"}})) == expected
+  end
+
   test "arrays" do
     assert_raise SyntaxError, fn -> parse!("[") end
     assert_raise SyntaxError, fn -> parse!("[,") end
@@ -93,5 +104,9 @@ defmodule Poison.ParserTest do
 
     assert parse!(~s({"foo": "bar"}), keys: :atoms) == %{foo: "bar"}
     assert parse!(~s({"foo": "bar"}), keys: :atoms!) == %{foo: "bar"}
+  end
+
+  def snakecase(json) do
+    parse!(json, key_transformer: Poison.SnakeCase)
   end
 end

--- a/test/poison/transformer_test.exs
+++ b/test/poison/transformer_test.exs
@@ -1,0 +1,26 @@
+defmodule Poison.TransformerTest do
+  use ExUnit.Case, async: true
+
+  test "Camel Case" do
+    assert camelcase("foo") == "foo"
+    assert camelcase("foo_bar") == "fooBar"
+    assert camelcase("_foo") == "foo"
+    assert camelcase("foo_") == "foo"
+    assert camelcase("_foo_") == "foo"
+    assert camelcase("_foo_bar") == "fooBar"
+  end
+
+  test "Snake Case" do
+    assert snakecase("foo") == "foo"
+    assert snakecase("fooBar") == "foo_bar"
+    assert snakecase("fooBARBaz") == "foo_bar_baz"
+  end
+
+  def camelcase(s) do
+    Poison.CamelCase.transform(s)
+  end
+
+  def snakecase(s) do
+    Poison.SnakeCase.transform(s)
+  end
+end


### PR DESCRIPTION
This is an attempt at solving #44. 

Syntax is as follows: 

```elixir
iex(1)> Poison.decode ~s({"fooBar": 1}), key_transformer: Poison.SnakeCase
{:ok, %{"foo_bar" => 1}}

iex(2)> Poison.encode %{foo_bar: 1}, key_transformer: Poison.CamelCase     
{:ok, "{\"fooBar\":1}"}
```
This probably kills performance, and needs some macros to fix it. However it's here as a working proposal for further discussion.

It's also likely that modifying Poison to do this is not as useful as making it a transformation step in the process. Similar to the comments in #55 this might be better done in a separate library.

Fixes #44.

Paired with @bockit