### PR TITLE
Add :except option to @derive 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ end
 For maximum performance, make sure you `@derive [Poison.Encoder]` for any struct
 you plan on encoding.
 
+### Encoding only some attributes
+
+When deriving structs for encoding, it is possible to select or exclude specific attributes. This is achieved by deriving `Poison.Encoder` with the `:only` or `:except` options set:
+
+```elixir
+defmodule PersonOnlyName do
+  @derive {Poison.Encoder, only: [:name]}
+  defstruct [:name, :age]
+end
+
+defmodule PersonWithoutName do
+  @derive {Poison.Encoder, except: [:name]}
+  defstruct [:name, :age]
+end
+```
+
+In case both `:only` and `:except` keys are defined, the `:except` option is ignored.
+
 ## Benchmarking
 
 ```sh-session

--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -316,10 +316,15 @@ defimpl Poison.Encoder, for: Any do
   end
 
   def deriving(module, _struct, options) do
-    extractor = if only = options[:only] do
-      quote(do: Map.take(struct, unquote(only)))
-    else
-      quote(do: :maps.remove(:__struct__, struct))
+    extractor = cond do
+      options[:only] ->
+        only = options[:only]
+        quote(do: Map.take(struct, unquote(only)))
+      options[:except] ->
+        except = [:__struct__ | options[:except]]
+        quote(do: Map.drop(struct, unquote(except)))
+      true ->
+        quote(do: :maps.remove(:__struct__, struct))
     end
 
     quote do

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -146,6 +146,11 @@ defmodule Poison.EncoderTest do
     defstruct name: "", size: 0
   end
 
+  defmodule DerivedUsingExcept do
+    @derive {Poison.Encoder, except: [:name]}
+    defstruct name: "", size: 0
+  end
+
   defmodule NonDerived do
     defstruct name: ""
   end
@@ -158,6 +163,9 @@ defmodule Poison.EncoderTest do
 
     derived_using_only = %DerivedUsingOnly{name: "derived using :only", size: 10}
     assert Poison.decode!(to_json(derived_using_only)) == %{"name" => "derived using :only"}
+
+    derived_using_except = %DerivedUsingExcept{name: "derived using :only", size: 10}
+    assert Poison.decode!(to_json(derived_using_except)) == %{"size" => 10}
   end
 
   test "EncodeError" do

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -164,7 +164,7 @@ defmodule Poison.EncoderTest do
     derived_using_only = %DerivedUsingOnly{name: "derived using :only", size: 10}
     assert Poison.decode!(to_json(derived_using_only)) == %{"name" => "derived using :only"}
 
-    derived_using_except = %DerivedUsingExcept{name: "derived using :only", size: 10}
+    derived_using_except = %DerivedUsingExcept{name: "derived using :except", size: 10}
     assert Poison.decode!(to_json(derived_using_except)) == %{"size" => 10}
   end
 


### PR DESCRIPTION
Hi there,

This PR is to add the `:except` option to the `@derive` clause in `Poison.Encoder`. The main reason behind this addition is easiness of usage with Ecto. I've seen quite some people complain about the fact that the `__meta__` attribute in Ecto models is messing up with Poison, and as of now, the only solution seems to `:only` the needed fields (often all of them but `__meta__`) in the `@derive` attribute before Ecto schema definitions.

Having an `:except` option, while seeming a natural counterpart for the already present `:only`, would make tackling that problem simpler, and definitely DRY'er. :grinning: 

I've also added a little sub-section in the `README.md` file, just to make the whole `only`/`except` thing clearer!