### PR TITLE
fixes #64 - updating documentation for nested decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Poison.decode!(~s({"name": "Devin Torres", "age": 27}), as: %Person{})
 #=> %Person{name: "Devin Torres", age: 27}
 
 Poison.decode!(~s({"people": [{"name": "Devin Torres", "age": 27}]}),
-  as: %{"people" => [Person]})
+  as: %{"people" => [%Person{}]})
 #=> %{"people" => [%Person{age: 27, name: "Devin Torres"}]}
 ```
 


### PR DESCRIPTION
Fixes documentation to correctly show how to use `Poison#decode!` with a nested list.