### PR TITLE
Update README with 1.x information

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ on their own without buying into other functionality. For example, if you were
 interested purely in the speed of parsing JSON without a decoding step, you
 could simply call `Poison.Parser.parse`.
 
+If you use Poison 1.x, you have to set a module to `as` option in order to
+decode into a struct. e.g. `as: Person` instead of `as: %Person{}`. The change was
+introduced at 2.0.0.
+
 ## Parser
 
 ```iex


### PR DESCRIPTION
I spent certain time to figure out why `Poison.decode!(~s({"name": "Devin Torres", "age": 27}), as: %Person{})` would give me an error. It turned out my phoenix project uses Poison 1.x and it doesn't support struct for `as` option.

There are still many libraries that depend on 1.x so I thought that it's a good idea to note the change. Someone like me could avoid making same mistake I made.

I also suggest to create `1.x` branch. That allows us to see the difference quickly instead of checking commit log.