### PR TITLE
decode nested struct lists with sensible defaults

### DIFF
--- a/lib/poison/decoder.ex
+++ b/lib/poison/decoder.ex
@@ -52,14 +52,22 @@ defmodule Poison.Decode do
   end
 
   defp do_transform_struct(value, keys, as, options) do
+    default = struct(as.__struct__)
+
     Map.from_struct(as)
     |> Enum.reduce(%{}, fn {key, as}, acc ->
-      case Map.get(value, key) do
+      new_value = case Map.get(value, key) do
         value when is_map(value) or is_list(value) ->
-          Map.put(acc, key, transform(value, keys, as, options))
-        value ->
-          Map.put(acc, key, value)
+          # value == as indicates we never actually recieved a value for `key`.
+          if value == as do
+            Map.get(default, key)
+          else
+            transform(value, keys, as, options)
+          end
+        value -> value
       end
+
+      Map.put(acc, key, new_value)
     end)
     |> Map.put(:__struct__, as.__struct__)
     |> Poison.Decoder.decode(options)

--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -15,6 +15,10 @@ defmodule Poison.DecoderTest do
     defstruct [:street, :city, :state, :zip]
   end
 
+  defmodule Person2 do
+   defstruct name: nil, age: 42, contacts: []
+  end
+
   defimpl Poison.Decoder, for: Address do
     def decode(address, _options) do
       "#{address.street}, #{address.city}, #{address.state}  #{address.zip}"
@@ -75,6 +79,38 @@ defmodule Poison.DecoderTest do
   test "decoding into nested structs" do
     person = %{"name" => "Devin Torres", "contact" => %{"email" => "devin@torres.com"}}
     assert decode(person, as: %Person{contact: %Contact{}}) == %Person{name: "Devin Torres", contact: %Contact{email: "devin@torres.com"}}
+  end
+
+  test "decoding into nested struct, empty nested struct" do
+    person = %{"name" => "Devin Torres"}
+    assert decode(person, as: %Person{contact: %Contact{}}) == %Person{name: "Devin Torres"}
+  end
+
+  test "decoding into nested struct list" do
+    person = %{"name" => "Devin Torres", "contacts" => [%{"email" => "devin@torres.com"}, %{"email" => "test@email.com"}]}
+    expected = %Person2{
+      name: "Devin Torres",
+      contacts: [
+        %Contact{email: "devin@torres.com"}, %Contact{email: "test@email.com"}]}
+
+    assert decode(person, as: %Person2{contacts: [%Contact{}]}) == expected
+  end
+
+  test "decoding into nested structs, empty list" do
+    person = %{"name" => "Devin Torres"}
+
+    expected = %Person2{
+      name: "Devin Torres",
+      contacts: []
+    }
+
+    assert decode(person, as: %Person2{contacts: [%Contact{}]}) == expected
+  end
+
+  test "decoding into nested structs list with nil overriding default" do
+    person = %{"name" => "Devin Torres", "contacts" => nil}
+
+    assert decode(person, as: %Person2{contacts: [%Contact{}]}) == %Person2{name: "Devin Torres", contacts: nil}
   end
 
   test "decoding into nested structs with nil overriding defaults" do


### PR DESCRIPTION
With nested struct decoding, the behavior is a little weird if the source map doesn't contain a matching field. The weirdness is especially noticeable when the nested struct is inside of a list:
```Elixir
defmodule Person do
  defstruct name: nil, age: 42, contacts: []
end

decode(%{"name" => "Devin Torres"}, as: %Person{contacts: [%Contact{}]})
```
Returns a struct like
```Elixir
%Poison.DecoderTest.Person{age: 42,
  contacts: [%Poison.DecoderTest.Contact{email: nil, telephone: nil}],
  name: "Devin Torres"}
```
In the example, the decoded result contains a one-element list for the `:contacts` field (with an "empty" contact struct), while the original source map contained no value at all for that field. I think it makes more sense to fall back to the default struct value for the field when the source map doesn't contain an entry for that field.

With this change, the result will now be
```Elixir
%Poison.DecoderTest.Person{age: 42, contacts: [], name: "Devin Torres"}
```