### PR TITLE
Add hint about syntax error location

### DIFF
--- a/lib/poison.ex
+++ b/lib/poison.ex
@@ -64,7 +64,7 @@ defmodule Poison do
       {:ok, [1, 2, 3]}
   """
   @spec decode(iodata, Keyword.t) :: {:ok, Parser.t} | {:error, :invalid}
-    | {:error, {:invalid, String.t}}
+    | {:error, {:invalid, String.t, String.t}}
   def decode(iodata, options \\ []) do
     case Parser.parse(iodata, options) do
       {:ok, value} -> {:ok, Decode.decode(value, options)}

--- a/test/poison/parser_test.exs
+++ b/test/poison/parser_test.exs
@@ -94,4 +94,9 @@ defmodule Poison.ParserTest do
     assert parse!(~s({"foo": "bar"}), keys: :atoms) == %{foo: "bar"}
     assert parse!(~s({"foo": "bar"}), keys: :atoms!) == %{foo: "bar"}
   end
+
+  test "error reporting" do
+    assert parse(~s({"foo": "bar". "baz": "quux"})) == {:error, {:invalid, ".", ~s( "baz": "q)}}
+    assert parse(~s({"foo": "bar", "baz"; "quux"})) == {:error, {:invalid, ";", ~s( "quux"}<END OF INPUT>)}}
+  end
 end


### PR DESCRIPTION
Hi,

the intention of the commit is to give the user a hint about the location of a syntax error.

My use case was that I was trying to use Poison to load a JSON data file for processing. Some tools are notoriously bad at escaping characters when exporting to a text file. The parsing failed with the following message: "Unexpected token: T". Since the data file was 150MB+ and contained sensitive data, I couldn't upload it to any of the online validation tools.

I considered two options:
- keep track of the current line and column in the input: the code required for this implementation would have to be spread out across all the parsing code,
- extend the result of Poison.Parser.parse upon error to add the text immediately following the syntax error: this allows the user to search for the specified pattern to find the syntax error; not a bulletproof solution, but the implementation does not affect the main flow and has next to no performance cost.

I also considered adding the expected input upon reaching the unexpected one, but it's independent to this one, so I didn't add it here.