### PR TITLE
Fix Nested Struct Decoding

### DIFF
--- a/lib/poison/decoder.ex
+++ b/lib/poison/decoder.ex
@@ -56,7 +56,7 @@ defmodule Poison.Decode do
 
     Map.from_struct(as)
     |> Enum.reduce(%{}, fn {key, as}, acc ->
-      new_value = case Map.get(value, key) do
+      new_value = case Map.get(value, key, Map.get(default, key)) do
         value when is_map(value) or is_list(value) ->
           # value == as indicates we never actually recieved a value for `key`.
           if value == as do

--- a/lib/poison/decoder.ex
+++ b/lib/poison/decoder.ex
@@ -52,14 +52,22 @@ defmodule Poison.Decode do
   end
 
   defp do_transform_struct(value, keys, as, options) do
+    default = struct(as.__struct__)
+
     Map.from_struct(as)
     |> Enum.reduce(%{}, fn {key, as}, acc ->
-      case Map.get(value, key) do
+      new_value = case Map.get(value, key) do
         value when is_map(value) or is_list(value) ->
-          Map.put(acc, key, transform(value, keys, as, options))
-        value ->
-          Map.put(acc, key, value)
+          # value == as indicates we never actually recieved a value for `key`.
+          if value == as do
+            Map.get(default, key)
+          else
+            transform(value, keys, as, options)
+          end
+        value -> value
       end
+
+      Map.put(acc, key, new_value)
     end)
     |> Map.put(:__struct__, as.__struct__)
     |> Poison.Decoder.decode(options)

--- a/lib/poison/decoder.ex
+++ b/lib/poison/decoder.ex
@@ -56,15 +56,19 @@ defmodule Poison.Decode do
 
     Map.from_struct(as)
     |> Enum.reduce(%{}, fn {key, as}, acc ->
-      new_value = case Map.get(value, key, Map.get(default, key)) do
-        value when is_map(value) or is_list(value) ->
-          # value == as indicates we never actually recieved a value for `key`.
+      new_value = case Map.fetch(value, key) do
+        {:ok, value} when is_map(value) or is_list(value) ->
+          # value == as indicates we never actually recieved a value for `key`
+          # and instead have the default value line 57 (which is from `as`).
           if value == as do
             Map.get(default, key)
           else
             transform(value, keys, as, options)
           end
-        value -> value
+        {:ok, value} ->
+          value
+        :error ->
+          Map.get(default, key)
       end
 
       Map.put(acc, key, new_value)

--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -15,6 +15,10 @@ defmodule Poison.DecoderTest do
     defstruct [:street, :city, :state, :zip]
   end
 
+  defmodule Person2 do
+   defstruct name: nil, age: 42, contacts: []
+  end
+
   defimpl Poison.Decoder, for: Address do
     def decode(address, _options) do
       "#{address.street}, #{address.city}, #{address.state}  #{address.zip}"
@@ -75,6 +79,38 @@ defmodule Poison.DecoderTest do
   test "decoding into nested structs" do
     person = %{"name" => "Devin Torres", "contact" => %{"email" => "devin@torres.com"}}
     assert decode(person, as: %Person{contact: %Contact{}}) == %Person{name: "Devin Torres", contact: %Contact{email: "devin@torres.com"}}
+  end
+
+  test "decoding into nested struct, empty nested struct" do
+    person = %{"name" => "Devin Torres"}
+    assert decode(person, as: %Person{contact: %Contact{}}) == %Person{name: "Devin Torres"}
+  end
+
+  test "decoding into nested struct list" do
+    person = %{"name" => "Devin Torres", "contacts" => [%{"email" => "devin@torres.com"}, %{"email" => "test@email.com"}]}
+    expected = %Person2{
+      name: "Devin Torres",
+      contacts: [
+        %Contact{email: "devin@torres.com"}, %Contact{email: "test@email.com"}]}
+
+    assert decode(person, as: %Person2{contacts: [%Contact{}]}) == expected
+  end
+
+  test "decoding into nested structs, empty list" do
+    person = %{"name" => "Devin Torres"}
+
+    expected = %Person2{
+      name: "Devin Torres",
+      contacts: []
+    }
+
+    assert decode(person, as: %Person2{contacts: [%Contact{}]}) == expected
+  end
+
+  test "decoding into nested structs list with nil overriding default" do
+    person = %{"name" => "Devin Torres", "contacts" => nil}
+
+    assert decode(person, as: %Person2{contacts: [%Contact{}]}) == %Person2{name: "Devin Torres", contacts: nil}
   end
 
   test "decoding into nested structs with nil overriding defaults" do

--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -19,6 +19,10 @@ defmodule Poison.DecoderTest do
    defstruct name: nil, age: 42, contacts: []
   end
 
+  defmodule Contact2 do
+    defstruct [:email, :telephone, call_count: 0]
+  end
+
   defimpl Poison.Decoder, for: Address do
     def decode(address, _options) do
       "#{address.street}, #{address.city}, #{address.state}  #{address.zip}"
@@ -87,13 +91,29 @@ defmodule Poison.DecoderTest do
   end
 
   test "decoding into nested struct list" do
-    person = %{"name" => "Devin Torres", "contacts" => [%{"email" => "devin@torres.com"}, %{"email" => "test@email.com"}]}
+    person = %{"name" => "Devin Torres", "contacts" => [%{"email" => "devin@torres.com", "call_count" => 10}, %{"email" => "test@email.com"}]}
     expected = %Person2{
       name: "Devin Torres",
       contacts: [
-        %Contact{email: "devin@torres.com"}, %Contact{email: "test@email.com"}]}
+        %Contact2{email: "devin@torres.com", call_count: 10},
+        %Contact2{email: "test@email.com", call_count: 0}
+      ]}
 
-    assert decode(person, as: %Person2{contacts: [%Contact{}]}) == expected
+    decoded = decode(person, as: %Person2{contacts: [%Contact2{}]})
+    assert decoded == expected
+  end
+
+  test "decoding into nested struct list with keys = :atoms" do
+    person = %{name: "Devin Torres", contacts: [%{email: "devin@torres.com", call_count: 10}, %{email: "test@email.com"}]}
+    expected = %Person2{
+      name: "Devin Torres",
+      contacts: [
+        %Contact2{email: "devin@torres.com", call_count: 10},
+        %Contact2{email: "test@email.com", call_count: 0}
+      ]}
+
+    decoded = decode(person, as: %Person2{contacts: [%Contact2{}]}, keys: :atoms)
+    assert decoded == expected
   end
 
   test "decoding into nested structs, empty list" do


### PR DESCRIPTION
This PR includes the fixes in #72, as well as resolving an issue where values decoded with `keys: :atoms` would not inherit default struct values.

I also rebased #72 against master.

## Demo of the issue

```ex
defmodule Person do
  defstruct name: "Unknown", friends: []
end
```

```ex
value = %{name: "Bob", friends: [%{name: "Dave"}, %{}]}
Poison.Decoder.decode(value, as: %Person{friends: [%Person{}]})
#fixed  => %Person{name: "Bob", friends: [%Person{name: "Dave"}, %Person{name: "Unknown"}]}
#before => %Person{name: "Bob", friends: [%Person{name: "Dave"}, %Person{name: nil}]}

```