### PR TITLE
Fixes #79. Default values in structs with atom keys

### DIFF
--- a/lib/poison/decoder.ex
+++ b/lib/poison/decoder.ex
@@ -40,7 +40,11 @@ defmodule Poison.Decode do
   end
 
   defp transform_struct(value, keys, as, options) when keys in [:atoms, :atoms!] do
-    do_transform_struct(value, keys, as, options)
+    Map.from_struct(as)
+    |> Enum.reduce(%{}, fn {key, default}, acc ->
+      Map.put acc, key, Map.get(value, key, default)
+    end)
+    |> do_transform_struct(keys, as, options)
   end
 
   defp transform_struct(value, keys, as, options) do

--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -67,6 +67,16 @@ defmodule Poison.DecoderTest do
     assert decode(person, as: %Person{age: 50}) == %Person{name: "Devin Torres", age: 50}
   end
 
+  test "decoding into structs with unspecified default values" do
+    person = %{"name" => "Devin Torres"}
+    assert decode(person, as: %Person{}) == %Person{name: "Devin Torres", age: 42}
+  end
+
+  test "decoding into structs with unspecified default values and atom keys" do
+    person = %{:name => "Devin Torres"}
+    assert decode(person, as: %Person{}, keys: :atoms!) == %Person{name: "Devin Torres", age: 42}
+  end
+
   test "decoding into structs with nil overriding defaults" do
     person = %{"name" => "Devin Torres", "age" => nil}
     assert decode(person, as: %Person{}) == %Person{name: "Devin Torres", age: nil}


### PR DESCRIPTION
When decoding structs with atom keys, ensure we include the struct's default values.