### PR TITLE
Fixes #91. Added option to ensure maps don't produce JSON with duplicate keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ end
 
 In case both `:only` and `:except` keys are defined, the `:except` option is ignored.
 
+### Key Validation
+
+According to [the JSON spec] keys in a JSON object should be unique. This is inforced and resolved in different ways in other libraries. In the Ruby JSON library for example, the output generated from encoding a hash with a duplicate key (say 1 is a string, the other an atom) will include both keys. When parsing JSON of this type, Chromium will override all previous values with the final one.
+
+Like Ruby, Poison will also generate JSON with duplicate keys. If you'd like to ensure that your generated json doesn't have this issue, you can pass the `strict_keys: true` option when encoding. This will force the encoding to fail.
+
+Note that validating keys and cause a small performance hit.
+
+```elixir
+  iex(1)> Poison.encode %{:foo => "foo1", "foo" => "foo2"}, strict_keys: true
+  {:error, {:invalid, %{:foo => "foo1", "foo" => "foo2"}}}
+```
+
 ## Benchmarking
 
 ```sh-session

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ In case both `:only` and `:except` keys are defined, the `:except` option is ign
 
 ### Key Validation
 
-According to [the JSON spec] keys in a JSON object should be unique. This is inforced and resolved in different ways in other libraries. In the Ruby JSON library for example, the output generated from encoding a hash with a duplicate key (say 1 is a string, the other an atom) will include both keys. When parsing JSON of this type, Chromium will override all previous values with the final one.
+According to [the JSON spec](https://tools.ietf.org/html/rfc7159#section-4) keys in a JSON object should be unique. This is enforced and resolved in different ways in other libraries. In the Ruby JSON library for example, the output generated from encoding a hash with a duplicate key (say 1 is a string, the other an atom) will include both keys. When parsing JSON of this type, Chromium will override all previous values with the final one.
 
 Like Ruby, Poison will also generate JSON with duplicate keys. If you'd like to ensure that your generated json doesn't have this issue, you can pass the `strict_keys: true` option when encoding. This will force the encoding to fail.
 
-Note that validating keys and cause a small performance hit.
+Note that validating keys can cause a small performance hit.
 
 ```elixir
   iex(1)> Poison.encode %{:foo => "foo1", "foo" => "foo2"}, strict_keys: true

--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -195,7 +195,9 @@ defimpl Poison.Encoder, for: Map do
   def encode(map, _) when map_size(map) < 1, do: "{}"
 
   def encode(map, options) do
-    encode(map, pretty(options), options)
+    map
+    |> check_key_integrity
+    |> encode(pretty(options), options)
   end
 
   def encode(map, true, options) do
@@ -212,6 +214,17 @@ defimpl Poison.Encoder, for: Map do
     fun = &[?,, Encoder.BitString.encode(encode_name(&1), options), ?:,
                 Encoder.encode(:maps.get(&1, map), options) | &2]
     [?{, tl(:lists.foldl(fun, [], :maps.keys(map))), ?}]
+  end
+
+  defp check_key_integrity(map) do
+    map
+    |> Enum.reduce(%{}, fn {key, value}, acc ->
+      normalised_key = encode_name(key)
+      case Map.has_key?(acc, normalised_key) do
+        true -> raise Poison.EncodeError, value: map
+        false -> Map.put(acc, normalised_key, value)
+      end
+    end)
   end
 end
 

--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -218,8 +218,7 @@ defimpl Poison.Encoder, for: Map do
 
   defp check_key_integrity(map, false), do: map
   defp check_key_integrity(map, true) do
-    map
-    |> Enum.reduce(%{}, fn {key, value}, acc ->
+    Enum.reduce(map, %{}, fn {key, value}, acc ->
       normalised_key = encode_name(key)
       case Map.has_key?(acc, normalised_key) do
         true -> raise Poison.EncodeError, value: map

--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -196,7 +196,7 @@ defimpl Poison.Encoder, for: Map do
 
   def encode(map, options) do
     map
-    |> check_key_integrity
+    |> check_key_integrity(Keyword.get(options, :strict_keys, false))
     |> encode(pretty(options), options)
   end
 
@@ -216,7 +216,8 @@ defimpl Poison.Encoder, for: Map do
     [?{, tl(:lists.foldl(fun, [], :maps.keys(map))), ?}]
   end
 
-  defp check_key_integrity(map) do
+  defp check_key_integrity(map, false), do: map
+  defp check_key_integrity(map, true) do
     map
     |> Enum.reduce(%{}, fn {key, value}, acc ->
       normalised_key = encode_name(key)

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -46,6 +46,9 @@ defmodule Poison.EncoderTest do
       }
     }\
     """
+
+    multi_key_map = %{"foo" => "foo1", :foo => "foo2"}
+    assert Poison.encode(multi_key_map) == {:error, {:invalid, multi_key_map}}
   end
 
   test "List" do

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -48,7 +48,8 @@ defmodule Poison.EncoderTest do
     """
 
     multi_key_map = %{"foo" => "foo1", :foo => "foo2"}
-    assert Poison.encode(multi_key_map) == {:error, {:invalid, multi_key_map}}
+    assert to_json(multi_key_map) == ~s({"foo":"foo1","foo":"foo2"})
+    assert Poison.encode(multi_key_map, strict_keys: true) == {:error, {:invalid, multi_key_map}}
   end
 
   test "List" do


### PR DESCRIPTION
Done in 2 commits to separate out the functionality.

The first validates they keys always - but slows the encoding down a bit.
The second makes the validation optional - the developer can trade off between speed and correctness

Any thoughts?