### PR TITLE
Introduce html_safe mode to prevent XSS

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -118,8 +118,8 @@ defimpl Poison.Encoder, for: BitString do
     [seq(char) | escape(rest, :javascript)]
   end
 
-  defp escape(<<char :: utf8>> <> rest, :html_safe) when char in '/' do
-    ['\\/' | escape(rest, :html_safe)]
+  defp escape(<<?/ :: utf8>> <> rest, :html_safe) do
+    ["\\/" | escape(rest, :html_safe)]
   end
 
   defp escape(<<char :: utf8>> <> rest, :html_safe) do

--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -118,6 +118,14 @@ defimpl Poison.Encoder, for: BitString do
     [seq(char) | escape(rest, :javascript)]
   end
 
+  defp escape(<<char :: utf8>> <> rest, :html_safe) when char in '/' do
+    ['\\/' | escape(rest, :html_safe)]
+  end
+
+  defp escape(<<char :: utf8>> <> rest, :html_safe) do
+    [char | escape(rest, :html_safe)]
+  end
+
   defp escape(string, mode) do
     size = chunk_size(string, mode, 0)
     <<chunk :: binary-size(size), rest :: binary>> = string

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -30,6 +30,7 @@ defmodule Poison.EncoderTest do
     assert to_json("☃", escape: :unicode) == ~s("\\u2603")
     assert to_json("𝄞", escape: :unicode) == ~s("\\uD834\\uDD1E")
     assert to_json("\u2028\u2029", escape: :javascript) == ~s("\\u2028\\u2029")
+    assert to_json("</script>", escape: :html_safe) == ~s("<\\/script>")
     assert to_json("áéíóúàèìòùâêîôûãẽĩõũ") == ~s("áéíóúàèìòùâêîôûãẽĩõũ")
   end
 


### PR DESCRIPTION
This PR adds another encoding mode called `:html_safe`. What it does is simply escape the `/` char in strings.

This ensures that the string will be XSS safe, ready to inject into the DOM. Without this, it's possible to easily pull off an XSS attack. 

```elixir
%{xssAttempt: "</script><script>debugger;</script>"} |> Poison.encode!(escape: :html_safe)
# "{\"xssAttempt\":\"<\\/script><script>debugger;<\\/script>\"}"
```

When parsing the string back out inside the browser, it won't get interpreted as an actual script tag, and you'll still get the contents you expected:

```html
<script>JSON.parse('{"xssAttempt":"<\\/script><script>debugger;<\\/script>"}')</script>
<!-- {xssAttempt: "</script><script>debugger;</script>"} -->
```

Notes:
The JSON spec allows the `/` to be escaped: http://www.json.org/
This approach is used elsewhere, for example in `yajl`: https://github.com/brianmario/yajl-ruby/commit/85e5aec53f6ae91d66c2d40fcf2634ec0d112e60

Thanks!
I'm definitely open to suggestions here...