### PR TITLE
Add support for encoding integers on map keys

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -19,9 +19,11 @@ defmodule Poison.Encode do
             value
           is_atom(value) ->
             Atom.to_string(value)
+          is_integer(value) ->
+            Integer.to_string(value)
           true ->
             raise Poison.EncodeError, value: value,
-              message: "expected string or atom key, got: #{inspect value}"
+              message: "expected string, atom or integer key, got: #{inspect value}"
         end
       end
     end

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -38,6 +38,7 @@ defmodule Poison.EncoderTest do
     assert to_json(%{}) == "{}"
     assert to_json(%{foo: :bar}) == ~s({"foo":"bar"})
     assert to_json(%{"foo" => "bar"})  == ~s({"foo":"bar"})
+    assert to_json(%{1475786353 => "ts"})  == ~s({"1475786353":"ts"})
     assert to_json(%{foo: %{bar: %{baz: "baz"}}}, pretty: true) == """
     {
       "foo": {
@@ -48,8 +49,8 @@ defmodule Poison.EncoderTest do
     }\
     """
 
-    multi_key_map = %{"foo" => "foo1", :foo => "foo2"}
-    assert to_json(multi_key_map) == ~s({"foo":"foo1","foo":"foo2"})
+    multi_key_map = %{"foo" => "foo1", :foo => "foo2", 1475786353 => "ts"}
+    assert to_json(multi_key_map) == ~s({"foo":"foo1","foo":"foo2","1475786353":"ts"})
     assert Poison.encode(multi_key_map, strict_keys: true) == {:error, {:invalid, "foo"}}
   end
 


### PR DESCRIPTION
Added support for encoding integers on map keys. Generally map(hash) integer keys are converted as string on JSON encoding libraries.
For-example in Ruby:

``` ruby
require "json"
{1 => 2}.to_json
=> "{\"1\":2}"
```
