### PR TITLE
README: add struct-free encode! and decode! examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ $ mix deps.get
 ## Usage
 
 ```elixir
+Poison.encode!(%{"age" => 27, "name" => "Devin Torres"})
+#=> "{\"name\":\"Devin Torres\",\"age\":27}"
+
+Poison.decode!(~s({"name": "Devin Torres", "age": 27}))
+#=> %{"age" => 27, "name" => "Devin Torres"}
+
 defmodule Person do
   @derive [Poison.Encoder]
   defstruct [:name, :age]


### PR DESCRIPTION
Someone visited #elixir-lang, confused about how to use Poison and convinced that they needed to make a struct before decoding.  Add a struct-free encode and decode example to the Usage section.