### PR TITLE
Fix match of invalid characters during encoding

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -162,7 +162,7 @@ defimpl Poison.Encoder, for: BitString do
     chunk_size(rest, mode, acc + size)
   end
 
-  defp chunk_size(<<char>>, _, _) do
+  defp chunk_size(<<char>> <> _rest, _, _) do
     raise Poison.EncodeError, value: <<char>>
   end
 


### PR DESCRIPTION
`Poison.encode` crashes with an FunctionClauseError when supplied with an invalid input (binaries with non-text content).