### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Poison takes several approaches to be the fastest JSON library for Elixir.
 
 Poison uses extensive [sub binary matching][1], a **hand-rolled parser** using
 several techniques that are [known to benefit HiPE][2] for native compilation,
-[IO list][3] encoding and **single-pass** decoding.
+[IO list][7] encoding and **single-pass** decoding.
 
 Poison benchmarks sometimes puts Poison's performance close to `jiffy` and
 usually faster than other Erlang/Elixir libraries.
@@ -215,7 +215,7 @@ Issue 90 (JSON)                     1   1964860.00 µs/op
 
 ## License
 
-Poison is released under [CC0-1.0][6] (see [`LICENSE`](LICENSE)).
+Poison is released under [CC0-1.0][8] (see [`LICENSE`](LICENSE)).
 
 [1]: http://www.erlang.org/euc/07/papers/1700Gustafsson.pdf
 [2]: http://www.erlang.org/workshop/2003/paper/p36-sagonas.pdf

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Poison takes several approaches to be the fastest JSON library for Elixir.
 
 Poison uses extensive [sub binary matching][1], a **hand-rolled parser** using
 several techniques that are [known to benefit HiPE][2] for native compilation,
-[IO list][7] encoding and **single-pass** decoding.
+[IO list][3] encoding and **single-pass** decoding.
 
 Poison benchmarks sometimes puts Poison's performance close to `jiffy` and
 usually faster than other Erlang/Elixir libraries.
@@ -96,7 +96,7 @@ iex> IO.puts Poison.Encoder.encode([1, 2, 3], [])
 ```
 
 Anything implementing the Encoder protocol is expected to return an
-[IO list][5] to be embedded within any other Encoder's implementation and
+[IO list][7] to be embedded within any other Encoder's implementation and
 passable to any IO subsystem without conversion.
 
 ```elixir


### PR DESCRIPTION
Hey there,

I was having a look at the readme and noticed the link to the license was wrong,
When I checked the commit a4208a6252f4e58fbcc8d9fd2f4f64c99e974cc8 I also noticed that [this line](https://github.com/devinus/poison/commit/a4208a6252f4e58fbcc8d9fd2f4f64c99e974cc8#diff-04c6e90faac2675aa89e2176d2eec7d8L94) was probably bad as well,

So this tries to fix it all,

Cheers,