### PR TITLE
discard utf8 and utf16 byte order mark

### DIFF
--- a/lib/poison/parser.ex
+++ b/lib/poison/parser.ex
@@ -42,6 +42,15 @@ defmodule Poison.Parser do
 
   @type t :: nil | true | false | list | float | integer | String.t | map
 
+  def parse!(<<0xEF, 0xBB, 0xBF, iodata :: binary>>, options) do
+    parse!(iodata, options)
+  end
+  def parse!(<<0xFE, 0xFF, iodata :: binary>>, options) do
+    parse!(iodata, options)
+  end
+  def parse!(<<0xFF, 0xFE, iodata :: binary>>, options) do
+    parse!(iodata, options)
+  end
   def parse!(iodata, options) do
     string = IO.iodata_to_binary(iodata)
     keys = Map.get(options, :keys)


### PR DESCRIPTION
relevant portion of the [rfc](https://tools.ietf.org/html/rfc7159):

```
implementations MUST NOT add a byte order mark to the beginning of a
JSON text.  In the interests of interoperability, implementations
that parse JSON texts MAY ignore the presence of a byte order mark
rather than treating it as an error.
```