### PR TITLE
Add map_to option to allow override json keys mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,23 @@ end
 In case both `:only` and `:except` keys are defined, the `:except` option is
 ignored.
 
+## Decoder
+
+### Override map keys
+
+Sometimes, when you can't or you don't want to change a JSON map, you will need to map some fields with one key to another.
+This can be achieved by using the option `map_to: %{"old_key" => "new_key"}`:
+
+```elixir
+defmodule Person do
+  @derive [Poison.Encoder]
+  defstruct [:name, :age]
+end
+
+Poison.decode!(~s({"user_name": "Devin Torres", "age": 27}), %{as: %Person{}, map_to: %{"user_name" => "name"}})
+#=> %Person{name: "Devin Torres", age: 27}
+```
+
 ### Key Validation
 
 According to [RFC 7159][4] keys in a JSON object should be unique. This is

--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -151,4 +151,52 @@ defmodule Poison.DecoderTest do
     address = %{"street" => "1 Main St.", "city" => "Austin", "state" => "TX", "zip" => "78701"}
     assert transform(address, %{as: %Address{}}) == "1 Main St., Austin, TX  78701"
   end
+
+  test "decoding using a key map rename" do
+    person = %{"name" => "Devin Torres", "some_contacts" => [%{"email" => "devin@torres.com", "call_count" => 10}, %{"email" => "test@email.com"}]}
+    expected = %Person2{
+      name: "Devin Torres",
+      contacts: [
+        %Contact2{email: "devin@torres.com", call_count: 10},
+        %Contact2{email: "test@email.com", call_count: 0}
+      ]}
+    decoded = transform(person, %{as: %Person2{contacts: [%Contact2{}]}, map_to: %{"some_contacts" => "contacts"}})
+    assert decoded == expected
+  end
+
+  test "decoding using a key map rename in a nested struct" do
+    person = %{"name" => "Devin Torres", "some_contacts" => [%{"email" => "devin@torres.com"}, %{"contact_email" => "test@email.com"}]}
+    expected = %Person2{
+      name: "Devin Torres",
+      contacts: [
+        %Contact2{email: "devin@torres.com", call_count: 0},
+        %Contact2{email: "test@email.com", call_count: 0}
+      ]}
+    decoded = transform(person, %{as: %Person2{contacts: [%Contact2{}]}, map_to: %{"some_contacts" => "contacts", "contact_email" => "email"}})
+    assert decoded == expected
+  end
+
+  test "decoding using a key map rename with keys = :atoms" do
+    person = %{name: "Devin Torres", contacts: [%{email: "devin@torres.com", call_count: 10}, %{email: "test@email.com"}]}
+    expected = %Person2{
+      name: "Devin Torres",
+      contacts: [
+        %Contact2{email: "devin@torres.com", call_count: 10},
+        %Contact2{email: "test@email.com", call_count: 0}
+      ]}
+    decoded = transform(person, %{as: %Person2{contacts: [%Contact2{}]}, keys: :atoms, map_to: %{"some_contacts" => "contacts"}})
+    assert decoded == expected
+  end
+
+  test "decoding using a key map rename which is not present" do
+    person = %{"name" => "Devin Torres", "contacts" => [%{"email" => "devin@torres.com", "call_count" => 10}, %{"email" => "test@email.com"}]}
+    expected = %Person2{
+      name: "Devin Torres",
+      contacts: [
+        %Contact2{email: "devin@torres.com", call_count: 10},
+        %Contact2{email: "test@email.com", call_count: 0}
+      ]}
+    decoded = transform(person, %{as: %Person2{contacts: [%Contact2{}]}, map_to: %{"some_contacts" => "contacts"}})
+    assert decoded == expected
+  end
 end


### PR DESCRIPTION
Sometimes, when you can't or you don't want to change a JSON map, you will need to map some fields with one key to another. This is motivated by an uncontrolled JSON response from an API call, where some fields are not fitting the expected naming from the struct.

I added an option `map_to` to override any key name from the parsed JSON.