### PR TITLE
ParseError: fix escape/1 on Elixir < 1.6

### DIFF
--- a/lib/poison/parser.ex
+++ b/lib/poison/parser.ex
@@ -1,8 +1,6 @@
 defmodule Poison.ParseError do
   @type t :: %__MODULE__{pos: integer, value: String.t}
 
-  alias Code.Identifier
-
   defexception pos: nil, value: nil, rest: nil
 
   def message(%{value: nil, pos: pos}) do
@@ -19,8 +17,14 @@ defmodule Poison.ParseError do
   end
 
   defp escape(token) do
-    {value, _} = Identifier.escape(<<token>>, ?\\)
-    value
+    Code.ensure_loaded(Code.Identifier)
+    if function_exported?(Code.Identifier, :escape, 2) do
+      {value, _} = apply(Code.Identifier, :escape, [<<token>>, ?\\])
+      value
+    else
+      # Elixir < 1.6
+      apply(Inspect.BitString, :escape, [<<token>>, ?\\])
+    end
   end
 end
 


### PR DESCRIPTION
fixes unit tests and compiler warnings, tested with Elixir 1.4 and 1.6