### PR TITLE
Handle unexpected input type for `decode/1` without raising an exception

### DIFF
--- a/lib/poison.ex
+++ b/lib/poison.ex
@@ -53,7 +53,7 @@ defmodule Poison do
   def decode(iodata, options \\ %{}) do
     {:ok, decode!(iodata, options)}
   rescue
-    exception in [ParseError, DecodeError] ->
+    exception in [ParseError, DecodeError, ArgumentError] ->
       {:error, exception}
   end
 

--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -151,4 +151,10 @@ defmodule Poison.DecoderTest do
     address = %{"street" => "1 Main St.", "city" => "Austin", "state" => "TX", "zip" => "78701"}
     assert transform(address, %{as: %Address{}}) == "1 Main St., Austin, TX  78701"
   end
+
+  test "decoding unsupported input types results in error response" do
+    for input <- [1, :foo, %{}, [], 1.2, nil] do
+      assert {:error, _exception} = Poison.decode(input)
+    end
+  end
 end


### PR DESCRIPTION
This fixes #165 when passing an unexpected input into `decode/1` that resulted in raising an exception. 