### PR TITLE
Proposing a new implementation for Range encoding

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -329,7 +329,7 @@ defimpl Poison.Encoder, for: List do
   end
 end
 
-defimpl Poison.Encoder, for: [Range, Stream, MapSet, HashSet] do
+defimpl Poison.Encoder, for: [Stream, MapSet, HashSet] do
   alias Poison.Encoder
 
   use Poison.Pretty
@@ -372,8 +372,8 @@ end
 defimpl Poison.Encoder, for: Range do
   alias Poison.Encoder
 
-  def encode(range, _options) do
-    Encoder.Map.encode(%{first: range.first, last: range.last})
+  def encode(range, options) do
+    Encoder.Map.encode(%{first: range.first, last: range.last}, options)
   end
 end
 

--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -369,6 +369,14 @@ defimpl Poison.Encoder, for: [Date, Time, NaiveDateTime, DateTime] do
   end
 end
 
+defimpl Poison.Encoder, for: Range do
+  alias Poison.Encoder
+
+  def encode(range, _options) do
+    Encoder.Map.encode(%{first: range.first, last: range.last})
+  end
+end
+
 defimpl Poison.Encoder, for: Any do
   alias Poison.{Encoder, EncodeError}
 

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -79,15 +79,22 @@ defmodule Poison.EncoderTest do
   end
 
   test "Range" do
-    assert to_json(1..3) == "[1,2,3]"
+    r1 = 1..10
+    assert to_json(r1, pretty: true) == """
+    {
+      "last": 10,
+      "first": 1
+    }\
+    """
 
-    assert to_json(1..3, pretty: true) == """
-           [
-             1,
-             2,
-             3
-           ]\
-           """
+    a = 1
+    b = 999999999
+    assert to_json(a..b, pretty: true) == """
+    {
+      "last": #{b},
+      "first": #{a}
+    }\
+    """
   end
 
   test "Stream" do


### PR DESCRIPTION
The previous implementation of `Encoder` for `Range` was putting all the possible elements into a list, so `1..10` resulted in `[1,2,3,4,5,6,7,8,9,10]`, and likewise, `1..999999999` would produce a huge message (which would actually freeze your computer).

The implementation I'm proposing simply treats a range as its underlying map, with a `:first` and a `:last` fields.