### PR TITLE
Filter the JSON based on a Value

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ end
 In case both `:only` and `:except` keys are defined, the `:except` option is
 ignored.
 
+It is also possible to exclude all attributes with a specific value.  This can be useful in the case where `Null` might mean something to an API and you don't want to send the attribute at all.
+
+```elixir
+defmodule SparsePerson do
+  @derive {Poison.Encoder, redact: :empty}
+  defstruct name: :empty, age: :empty
+end
+```
+
+The `:redact` option can be included with `:only` and `:except`
+
 ### Key Validation
 
 According to [RFC 7159][4] keys in a JSON object should be unique. This is

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -196,6 +196,21 @@ defmodule Poison.EncoderTest do
     defstruct name: "", size: 0
   end
 
+  defmodule DerivedUsingRedact do
+    @derive {Poison.Encoder, redact: :empty}
+    defstruct name: :empty, size: 0
+  end
+
+  defmodule DerivedUsingOnlyAndRedact do
+    @derive {Poison.Encoder, only: [:name, :size], redact: :empty}
+    defstruct name: "", size: :empty, shape: "tirangle"
+  end
+
+  defmodule DerivedUsingExceptAndRedact do
+    @derive {Poison.Encoder, except: [:name], redact: :empty}
+    defstruct name: "", size: 10, shape: :empty
+  end
+
   defmodule NonDerived do
     defstruct name: ""
   end
@@ -221,6 +236,29 @@ defmodule Poison.EncoderTest do
     }
 
     assert Poison.decode!(to_json(derived_using_except)) == %{"size" => 10}
+
+    derived_using_redact = %DerivedUsingRedact{
+      name: :empty,
+      size: 10
+    }
+
+    assert Poison.decode!(to_json(derived_using_redact)) == %{"size" => 10}
+
+    derived_using_only_and_redact = %DerivedUsingOnlyAndRedact{
+      name: "test",
+      size: :empty,
+      shape: "tirangle"
+    }
+
+    assert Poison.decode!(to_json(derived_using_only_and_redact)) == %{"name" => "test"}
+
+    derived_using_except_and_redact = %DerivedUsingExceptAndRedact{
+      name: "test",
+      size: 10,
+      shape: :empty
+    }
+
+    assert Poison.decode!(to_json(derived_using_except_and_redact)) == %{"size" => 10}
   end
 
   test "EncodeError" do


### PR DESCRIPTION
This adds a `redact` option to the derive.

I've recently had a few situations where it is undesirable to send `null` to an external API (`GraphQL`, `enum` attributes).  I've implemented a couple of ugly solutions in my own code but thought it would be really nice if I could just specify an explicit _empty_ indicator and have that entire pair omitted from the generated `JSON`.

This PR does that.