### PR TITLE
Update README to use current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ First, add Poison to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:poison, "~> 3.1"}]
+  [{:poison, "~> 4.0"}]
 end
 ```
 


### PR DESCRIPTION
The current released version says it's in 4.0.1 so I just updated the version in the installation.