### PR TITLE
Support decode datetime

### DIFF
--- a/lib/poison/parser.ex
+++ b/lib/poison/parser.ex
@@ -89,9 +89,14 @@ defmodule Poison.Parser do
     array_values(rest, pos, keys, [])
   end
 
-  defp value("null" <> rest, pos, _keys, _format_datetime), do: {nil, pos + 4, rest}
-  defp value("true" <> rest, pos, _keys, _format_datetime), do: {true, pos + 4, rest}
-  defp value("false" <> rest, pos, _keys, _format_datetime), do: {false, pos + 5, rest}
+  defp value("null" <> rest, pos, _keys, _format_datetime),
+    do: {nil, pos + 4, rest}
+
+  defp value("true" <> rest, pos, _keys, _format_datetime),
+    do: {true, pos + 4, rest}
+
+  defp value("false" <> rest, pos, _keys, _format_datetime),
+    do: {false, pos + 5, rest}
 
   defp value(<<char, _::binary>> = string, pos, _keys, _format_datetime)
        when char in '-0123456789' do

--- a/test/poison/parser_test.exs
+++ b/test/poison/parser_test.exs
@@ -199,68 +199,78 @@ defmodule Poison.ParserTest do
   end
 
   test "parse date" do
-    date =
-      %Date{
-        calendar: Calendar.ISO,
-        day: 10,
-        month: 10,
-        year: 2018
-      }
+    date = %Date{
+      calendar: Calendar.ISO,
+      day: 10,
+      month: 10,
+      year: 2018
+    }
 
     assert parse!("\"2018-10-10\"", %{format_datetime: :date}) == date
-    assert parse!("{ \"date\": \"2018-10-10\" }", %{format_datetime: :date}) == %{"date" => date}
+
+    assert parse!("{ \"date\": \"2018-10-10\" }", %{format_datetime: :date}) ==
+             %{"date" => date}
   end
 
   test "parse time" do
-    time =
-      %Time{
-        calendar: Calendar.ISO,
-        hour: 1,
-        minute: 8,
-        second: 52,
-        microsecond: {735272, 6}
-      }
+    time = %Time{
+      calendar: Calendar.ISO,
+      hour: 1,
+      minute: 8,
+      second: 52,
+      microsecond: {735_272, 6}
+    }
 
     assert parse!("\"01:08:52.735272\"", %{format_datetime: :time}) == time
-    assert parse!("{ \"time\": \"01:08:52.735272\" }", %{format_datetime: :time}) == %{"time" => time}
+
+    assert parse!("{ \"time\": \"01:08:52.735272\" }", %{format_datetime: :time}) ==
+             %{"time" => time}
   end
 
   test "parse datetime" do
-    datetime =
-      %DateTime{
-        calendar: Calendar.ISO,
-        day: 11,
-        hour: 0,
-        microsecond: {262450, 6},
-        minute: 12,
-        month: 10,
-        second: 41,
-        std_offset: 0,
-        time_zone: "Etc/UTC",
-        utc_offset: 0,
-        year: 2018,
-        zone_abbr: "UTC"
-      }
+    datetime = %DateTime{
+      calendar: Calendar.ISO,
+      day: 11,
+      hour: 0,
+      microsecond: {262_450, 6},
+      minute: 12,
+      month: 10,
+      second: 41,
+      std_offset: 0,
+      time_zone: "Etc/UTC",
+      utc_offset: 0,
+      year: 2018,
+      zone_abbr: "UTC"
+    }
 
-    assert parse!("\"2018-10-11T00:12:41.262450Z\"", %{format_datetime: :datetime}) == datetime
-    assert parse!("{ \"datetime\": \"2018-10-11T00:12:41.262450Z\" }", %{format_datetime: :datetime}) == %{"datetime" => datetime}
+    assert parse!("\"2018-10-11T00:12:41.262450Z\"", %{
+             format_datetime: :datetime
+           }) == datetime
+
+    assert parse!("{ \"datetime\": \"2018-10-11T00:12:41.262450Z\" }", %{
+             format_datetime: :datetime
+           }) == %{"datetime" => datetime}
   end
 
   test "parse naive datetime" do
-    naive_datetime =
-      %NaiveDateTime{
-        calendar: Calendar.ISO,
-        day: 10,
-        hour: 1,
-        minute: 13,
-        month: 10,
-        second: 20,
-        microsecond: {712433, 6},
-        year: 2018
-      }
+    naive_datetime = %NaiveDateTime{
+      calendar: Calendar.ISO,
+      day: 10,
+      hour: 1,
+      minute: 13,
+      month: 10,
+      second: 20,
+      microsecond: {712_433, 6},
+      year: 2018
+    }
 
-    assert parse!("\"2018-10-10T01:13:20.712433\"", %{format_datetime: :naive_datetime}) == naive_datetime
-    assert parse!("{ \"naive_datetime\": \"2018-10-10T01:13:20.712433\" }", %{format_datetime: :naive_datetime}) == %{"naive_datetime" => naive_datetime}
+    assert parse!("\"2018-10-10T01:13:20.712433\"", %{
+             format_datetime: :naive_datetime
+           }) == naive_datetime
+
+    assert parse!("{ \"naive_datetime\": \"2018-10-10T01:13:20.712433\" }", %{
+             format_datetime: :naive_datetime
+           }) == %{"naive_datetime" => naive_datetime}
   end
 
   defp parse!(iodata) do


### PR DESCRIPTION
Linked to https://github.com/devinus/poison/issues/174

To use the datetime decode feature is just need to request it in the options, like:

```elixir
%{now: Time.utc_now()}
|> Poison.encode!()
|> Poison.decode!(format_datetime: :time)

# %{"now" => ~T[02:24:23.871934]}

%{now: Date.utc_today()}
|> Poison.encode!()
|> Poison.decode!(format_datetime: :date)

# %{"now" => ~D[2018-10-11]}

%{now: DateTime.utc_now()}
|> Poison.encode!()
|> Poison.decode!(format_datetime: :datetime)

# %{"now" => #DateTime<2018-10-11 02:25:05.251816Z>}

%{now: NaiveDateTime.utc_now()}
|> Poison.encode!()
|> Poison.decode!(format_datetime: :naive_datetime)

# %{"now" => ~N[2018-10-11 02:25:13.460277]}
```