### PR TITLE
Add Remap Protocol

### DIFF
--- a/lib/poison/decoder.ex
+++ b/lib/poison/decoder.ex
@@ -31,7 +31,8 @@ defmodule Poison.Decode do
   defp transform(nil, _keys, _as, _options), do: nil
 
   defp transform(value, keys, %{__struct__: _} = as, options) do
-    transform_struct(value, keys, as, options)
+    Decoder.Remap.remap( as, value, keys )
+    |> transform_struct(keys, as, options)
   end
 
   defp transform(value, keys, as, options) when is_map(as) do
@@ -122,4 +123,31 @@ defimpl Poison.Decoder, for: Any do
   def decode(value, _options) do
     value
   end
+end
+
+defprotocol Poison.Decoder.Remap do
+  @moduledoc """
+  Hook via protocol for adjusting keys or the value map in general
+  when decoding to a struct. remap gets called after parsing but before
+  decoding to an `as` target. Base use case is translating camelCase
+  keys to under_score.
+
+  ```
+  defimpl Poison.Decoder.Remap, for: Contact2 do
+    def remap( _as, contact, keys ) when keys in [ :atoms, :atoms! ], do: contact
+    def remap( _as, contact, _keys ) do
+      Map.new( contact, fn { k, v } -> { Macro.underscore( k ), v } end )
+    end
+  end
+  ```
+  """
+
+  @fallback_to_any true
+  @type keys :: :atoms | :atoms!
+  @spec remap( as :: struct, value :: map, keys :: keys ) :: map
+  def remap( as, value, keys )
+end
+
+defimpl Poison.Decoder.Remap, for: Any do
+  def remap( _as, value, _keys ), do: value
 end

--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -29,6 +29,13 @@ defmodule Poison.DecoderTest do
     end
   end
 
+  defimpl Poison.Decoder.Remap, for: Contact2 do
+    def remap( _as, contact, keys ) when keys in [ :atoms, :atoms! ], do: contact
+    def remap( _as, contact, _keys ) do
+      Map.new( contact, fn { k, v } -> { Macro.underscore( k ), v } end )
+    end
+  end
+
   test "decoding single :as with string keys" do
     person = %{"name" => "Devin Torres", "age" => 27}
     expected = %Person{name: "Devin Torres", age: 27}
@@ -196,5 +203,15 @@ defmodule Poison.DecoderTest do
 
     assert transform(address, %{as: %Address{}}) ==
              "1 Main St., Austin, TX  78701"
+  end
+
+  test "decoding using remapping with camel case string keys" do
+    contact2 = %{ "callCount" => 7, "email" => "abc@123" }
+    assert transform(contact2, %{as: %Contact2{}}) == %Poison.DecoderTest.Contact2{ call_count: 7, email: "abc@123" }
+  end
+
+  test "decoding using remapping with camel case atom keys" do
+    contact2 = %{ :callCount => 7, :email => "abc@123" }
+    assert transform(contact2, %{as: %Contact2{}, keys: :atoms}) == %Poison.DecoderTest.Contact2{ call_count: 0, email: "abc@123" }
   end
 end


### PR DESCRIPTION
Intended for making key adjustments post Parse prior
to Decode. Base case for camelCase to under_score.