### PR TITLE
Restore Poison.Parser.parse/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ iex> Poison.Parser.parse!(~s({"name": "Devin Torres", "age": 27}), %{})
 %{"name" => "Devin Torres", "age" => 27}
 iex> Poison.Parser.parse!(~s({"name": "Devin Torres", "age": 27}), %{keys: :atoms!})
 %{name: "Devin Torres", age: 27}
+iex> Poison.Parser.parse(~s({"name": "Devin Torres", "age": 27}), %{})
+{:ok, %{"name" => "Devin Torres", "age" => 27}}
+iex> Poison.Parser.parse(~s({"name": "Devin Torres", "age": 27}), %{keys: :atoms!})
+{:ok, %{name: "Devin Torres", age: 27}}
 ```
 
 Note that `keys: :atoms!` reuses existing atoms, i.e. if `:name` was not

--- a/lib/poison/parser.ex
+++ b/lib/poison/parser.ex
@@ -72,6 +72,13 @@ defmodule Poison.Parser do
       reraise %ParseError{value: iodata}, stacktrace()
   end
 
+  def parse(iodata, options) do
+    {:ok, parse!(iodata, options)}
+  rescue
+    error in [ParseError] ->
+      {:error, error}
+  end
+
   defp value("\"" <> rest, pos, _keys) do
     string_continue(rest, pos + 1, [])
   end


### PR DESCRIPTION
`Poison.Parser.parse/2` was removed in https://github.com/devinus/poison/commit/a4208a6252f4e58fbcc8d9fd2f4f64c99e974cc8#diff-574cf330de0ee486ba021c9eaa1f0e7bL34

This PR brings it back for API consistency.