### PR TITLE
Add Poison.encode_to_iodata(!)/2 back

### DIFF
--- a/lib/poison.ex
+++ b/lib/poison.ex
@@ -28,7 +28,7 @@ defmodule Poison do
   Encode a value to JSON as iodata.
 
       iex> Poison.encode_to_iodata([1, 2, 3])
-      {:ok, [91, "1", [44, "2", 44, "3"], 93]}
+      {:ok, [91, ["1", 44, "2", 44, "3"], 93]}
   """
   @spec encode_to_iodata(Encoder.t, Keyword.t) :: {:ok, iodata} | {:error, {:invalid, any}}
   def encode_to_iodata(value, options \\ []) do
@@ -60,7 +60,7 @@ defmodule Poison do
   Encode a value to JSON as iodata, raises an exception on error.
 
       iex> Poison.encode_to_iodata!([1, 2, 3])
-      [91, "1", [44, "2", 44, "3"], 93]
+      [91, ["1", 44, "2", 44, "3"], 93]
   """
   @spec encode_to_iodata!(Encoder.t, Keyword.t) :: iodata | no_return
   def encode_to_iodata!(value, options \\ []) do

--- a/lib/poison.ex
+++ b/lib/poison.ex
@@ -25,6 +25,17 @@ defmodule Poison do
   end
 
   @doc """
+  Encode a value to JSON as iodata.
+
+      iex> Poison.encode_to_iodata([1, 2, 3])
+      {:ok, [91, "1", [44, "2", 44, "3"], 93]}
+  """
+  @spec encode_to_iodata(Encoder.t, Keyword.t) :: {:ok, iodata} | {:error, {:invalid, any}}
+  def encode_to_iodata(value, options \\ []) do
+    encode(value, [iodata: true] ++ options)
+  end
+
+  @doc """
   Encode a value to JSON, raises an exception on error.
 
       iex> Poison.encode!([1, 2, 3])
@@ -43,6 +54,17 @@ defmodule Poison do
     else
       value |> Encoder.encode(options) |> IO.iodata_to_binary()
     end
+  end
+
+  @doc """
+  Encode a value to JSON as iodata, raises an exception on error.
+
+      iex> Poison.encode_to_iodata!([1, 2, 3])
+      [91, "1", [44, "2", 44, "3"], 93]
+  """
+  @spec encode_to_iodata!(Encoder.t, Keyword.t) :: iodata | no_return
+  def encode_to_iodata!(value, options \\ []) do
+    encode!(value, [iodata: true] ++ options)
   end
 
   @doc """


### PR DESCRIPTION
I was updating libraries in one of the elixir applications where phoenix is configured to use Poison as a `:json_library`. Unfortunately, current version of Poison is not compatible with Phoenix because phoenix expects json_library to implement `encode_to_iodata!/2` (for example [here](https://github.com/phoenixframework/phoenix/blob/d90f7cfd453201fef1a869156b04c3f5bb1ffe3f/lib/phoenix/controller.ex#L284))

This PR is just a cherri-pick of the commit from https://github.com/devinus/poison/pull/19
Those changes were lost in [this PR](https://github.com/devinus/poison/commit/a4208a6252f4e58fbcc8d9fd2f4f64c99e974cc8#diff-50ab230cfbf0383eb7020a4c5f5e9d3c5e2f74783d1dd03ae8b6923f842f169f)


Or is this drop of those functions intentional?