### PR TITLE
update decode!() usage examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ end
 Poison.encode!(%Person{name: "Devin Torres", age: 27})
 #=> "{\"name\":\"Devin Torres\",\"age\":27}"
 
-Poison.decode!(~s({"name": "Devin Torres", "age": 27}), as: %Person{})
+Poison.decode!(~s({"name": "Devin Torres", "age": 27}), %{as: %Person{}})
 #=> %Person{name: "Devin Torres", age: 27}
 
 Poison.decode!(~s({"people": [{"name": "Devin Torres", "age": 27}]}),
-  as: %{"people" => [%Person{}]})
+  %{as: %{"people" => [%Person{}]}})
 #=> %{"people" => [%Person{age: 27, name: "Devin Torres"}]}
 ```
 


### PR DESCRIPTION
Fixes usage examples for `decode!/2` with the `as:` option as identified in #199 