### PR TITLE
Bring back Phoenix compatibility

### DIFF
--- a/lib/poison.ex
+++ b/lib/poison.ex
@@ -45,6 +45,10 @@ defmodule Poison do
     end
   end
 
+  def encode_to_iodata!(value) do
+    encode!(value, iodata: true)
+  end
+
   @doc """
   Decode JSON to a value.
 

--- a/lib/poison.ex
+++ b/lib/poison.ex
@@ -45,6 +45,13 @@ defmodule Poison do
     end
   end
 
+  @doc """
+  Encodes a value to JSON, returning an iodata.
+
+  Equivalent to `encode!(value, iodata: true)`.
+
+  This function exists for compatibility with Phoenix, always prefer `encode!/1`.
+  """
   def encode_to_iodata!(value) do
     encode!(value, iodata: true)
   end


### PR DESCRIPTION
Hi! Dropping `encode_to_iodata!/1` has lead to losing compatibility with Phoenix as can be seen with https://github.com/phoenixframework/phoenix/pull/4727. If this PR gets accepted it will unblock https://github.com/phoenixframework/phoenix/pull/4728 which brings that compatibility back.