### PR TITLE
Allow decoder as option to be a function

### DIFF
--- a/lib/poison/decoder.ex
+++ b/lib/poison/decoder.ex
@@ -42,6 +42,10 @@ defmodule Poison.Decode do
     for v <- value, do: transform(v, keys, as, options)
   end
 
+  defp transform(value, keys, as, options) when is_function(as, 1) do
+    transform(value, keys, as.(value), options)
+  end
+
   defp transform(value, _keys, _as, _options) do
     value
   end
@@ -106,7 +110,7 @@ end
 defprotocol Poison.Decoder do
   @fallback_to_any true
 
-  @typep as :: map | struct | [as]
+  @typep as :: map | struct | [as] | (t -> as | [as])
 
   @type options :: %{
           optional(:keys) => :atoms | :atoms!,

--- a/test/poison/decoder_test.exs
+++ b/test/poison/decoder_test.exs
@@ -197,4 +197,40 @@ defmodule Poison.DecoderTest do
     assert transform(address, %{as: %Address{}}) ==
              "1 Main St., Austin, TX  78701"
   end
+
+  test "decoding a sigle :as function with string keys" do
+    person = %{"name" => "Devin Torres"}
+    as = fn %{"name" => _name} -> %Person{} end
+    expected = %Person{name: "Devin Torres"}
+    assert transform(person, %{as: as}) == expected
+  end
+
+  test "decoding a single :as function with atom keys" do
+    person = %{name: "Devin Torres"}
+    as = fn %{name: _name} -> %Person{} end
+    expected = %Person{name: "Devin Torres"}
+    assert transform(person, %{as: as, keys: :atoms!}) == expected
+  end
+
+  test "decoding a :as list function with string keys" do
+    person = [%{"name" => "Devin Torres"}]
+    as = fn _value -> [%Person{}] end
+    expected = [%Person{name: "Devin Torres"}]
+    assert transform(person, %{as: as}) == expected
+  end
+
+  test "decoding nested :as function with string keys" do
+    person = %{"person" => %{"name" => "Devin Torres"}}
+    as = fn _value -> %{"person" => %Person{}} end
+    actual = transform(person, %{as: as})
+    expected = %{"person" => %Person{name: "Devin Torres"}}
+    assert actual == expected
+  end
+
+  test "decoding nested structs in :as function with string keys" do
+    person = %{"name" => "Devin Torres", "contact" => %{"email" => "test@email.com"}}
+    as = fn _value -> %Person{contact: %Contact{}} end
+    expected = %Person{name: "Devin Torres", contact: %Contact{email: "test@email.com"}}
+    assert transform(person, %{as: as}) == expected
+  end
 end


### PR DESCRIPTION
This PR adds a change that allows the option `as` value to be a function which is useful when you want decode to structs dynamically based on the json received:

```elixir
person = ~s({"name":"Devin Torres"})
contact = ~s({"email":"test@dev.com"})

as = fn
   %{"name" => _name} -> %Person{}
   %{"email" => _email} -> %Contact{}
end

Poison.decode!(person, %{as: as})
# %Person{name: "Devin Torres"}

Poison.decode!(contact, %{as: as})
# %Contact{email: "test@dev.com"}
```