### PR TITLE
Use import Bitwise instead of use Bitwise

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -109,7 +109,7 @@ defimpl Poison.Encoder, for: Atom do
 end
 
 defimpl Poison.Encoder, for: BitString do
-  use Bitwise
+  import Bitwise
 
   @compile :inline
   @compile :inline_list_funcs

--- a/lib/poison/parser.ex
+++ b/lib/poison/parser.ex
@@ -62,7 +62,7 @@ defmodule Poison.Parser do
   @compile {:inline_size, 150}
   @compile {:inline_unroll, 3}
 
-  use Bitwise
+  import Bitwise
 
   alias Poison.{Decoder, ParseError}
 


### PR DESCRIPTION
See: https://hexdocs.pm/elixir/1.14.1/changelog.html#4-hard-deprecations