### PR TITLE
Fix CI and upgrade test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,28 +18,30 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
-          - windows-latest
-          - windows-2022
-          - macos-11
+          - ubuntu-20.04
         otp:
-          - '24.1'
-          - '24.0'
-          - '23.3'
-          - '23.2'
-          - '23.1'
-          - '23.0'
+          - '25.1.2'
+          - '24.3.4.7'
+          - '23.3.4.9'
         elixir:
+          - '1.14.2'
+          - '1.13.2'
           - '1.12.3'
-          - '1.12.2'
-          - '1.12.1'
-          - '1.12.0'
           - '1.11.4'
-          - '1.11.3'
-          - '1.11.2'
-          - '1.11.1'
-          - '1.11.0'
-
+        exclude:
+          - otp: '25.1.2'
+            elixir: '1.12.3'
+          - otp: '25.1.2'
+            elixir: '1.11.4'
+            # breaks with test/poison/encoder_test.exs:70
+            # Clause:    value <- json_string()
+            # Generated: "\uFEFF"
+            # Assertion with == failed
+            # code:  assert to_json(value) == inspect(value)
+            # left:  "\"\uFEFF\""
+            # right: "\"\\uFEFF\""
+          - otp: '23.3.4.9'
+            elixir: '1.12.3'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
* Broke it down into the list of most relevant versions in 2022
* Specify the ubuntu version - 'latest' is mutable, at least the tests will work now until it's deprecated.
* Testing on OSX - the ERLEF doesn't support it, only windows and Linux
* Testing on Windows - can't see the point, no native code in Poison implementation.
* Use the latest patch versions of Elixir/Erlang - it's a best practice not to use the alpha 1.14.0 versions anyway.
* Love this project, thanks, it's so much easier to use and better for rapid integration than Jason IMHO x 