### PR TITLE
added encoding function for tuple datatype

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -98,6 +98,47 @@ defprotocol Poison.Encoder do
   def encode(value, options)
 end
 
+defimpl Poison.Encoder, for: Tuple do
+  alias Poison.{Encoder, Pretty}
+
+  use Poison.{Encode, Pretty}
+
+  @compile :inline
+  @compile :inline_list_funcs
+
+  def encode({}, _options), do: "{}"
+
+  def encode(tuple, options) do
+    tuple_to_list = Tuple.to_list(tuple)
+    encode(tuple_to_list, pretty(options), options)
+  end
+
+  @spec encode(list, boolean, any) :: [...]
+  def encode(tuple_to_list, false, options) do
+    [?{, tl(:lists.foldr(&[?,, Encoder.encode(&1, options) | &2], [], tuple_to_list)), ?}]
+  end
+
+  def encode(tuple_to_list, true, options) do
+    indent = indent(options)
+    offset = offset(options) + indent
+    options = offset(options, offset)
+
+    [
+      "{\n",
+      tl(
+        :lists.foldr(
+          &[",\n", spaces(offset), Encoder.encode(&1, options) | &2],
+          [],
+          tuple_to_list
+        )
+      ),
+      ?\n,
+      spaces(offset - indent),
+      ?}
+    ]
+  end
+end
+
 defimpl Poison.Encoder, for: Atom do
   def encode(nil, _options), do: "null"
   def encode(true, _options), do: "true"

--- a/test/poison/encoder_test.exs
+++ b/test/poison/encoder_test.exs
@@ -99,6 +99,12 @@ defmodule Poison.EncoderTest do
     end
   end
 
+  property "Tuple" do
+    check all(value <- json_list(min_length: 1)) do
+      assert String.match?(to_json({value}), ~r/^\{.*\}$/)
+    end
+  end
+
   test "Map" do
     assert to_json(%{}) == "{}"
     assert to_json(%{"foo" => "bar"}) == ~s({"foo":"bar"})


### PR DESCRIPTION
### Encoding tuple using Poison:
- Converted the tuple to List using `Tuple.to_list({1, 2.5,:atom , ‘string’})` operation then encoded the list using `lists:foldr` erlang function for iteration, which iterates in reverse order and each iterated value is encoded using respective encoding datatype function.

Input given:
![image](https://user-images.githubusercontent.com/108652545/218459959-9b696689-1b78-4403-89c6-c1d3790cc656.png)


 output:
![Screenshot from 2023-02-13 12-21-48](https://user-images.githubusercontent.com/108652545/218459346-cf5a064c-8d66-4611-a28e-fea06885ee18.png)


