### PR TITLE
Replace Deprecated Bitwise Usage in Poison.Encoder.BitString

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -109,7 +109,7 @@ defimpl Poison.Encoder, for: Atom do
 end
 
 defimpl Poison.Encoder, for: BitString do
-  use Bitwise
+  import Bitwise
 
   @compile :inline
   @compile :inline_list_funcs


### PR DESCRIPTION
This PR addresses a deprecation warning in the Poison.Encoder.BitString module. The 'use Bitwise' statement at line 112 has been replaced with 'import Bitwise' to comply with recent Elixir language updates.