### PR TITLE
Fix: never decode integers as `Decimal`s

### DIFF
--- a/lib/poison/parser.ex
+++ b/lib/poison/parser.ex
@@ -394,6 +394,10 @@ defmodule Poison.Parser do
 
   @compile {:inline, number_complete: 5}
 
+  defp number_complete(_decimal, skip, sign, coef, 0) do
+    [coef * sign | skip]
+  end
+
   if Code.ensure_loaded?(Decimal) do
     defp number_complete(true, skip, sign, coef, exp) do
       [%Decimal{sign: sign, coef: coef, exp: exp} | skip]
@@ -402,10 +406,6 @@ defmodule Poison.Parser do
     defp number_complete(true, _skip, _sign, _coef, _exp) do
       raise Poison.MissingDependencyError, name: "Decimal"
     end
-  end
-
-  defp number_complete(_decimal, skip, sign, coef, 0) do
-    [coef * sign | skip]
   end
 
   max_sig = 1 <<< 53

--- a/test/poison/parser_test.exs
+++ b/test/poison/parser_test.exs
@@ -54,10 +54,11 @@ defmodule Poison.ParserTest do
     # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
     assert parse!("123456789.123456789e123") === 1.234567891234568e131
 
-    assert parse!("0", %{decimal: true}) == Decimal.new("0")
-    assert parse!("-0", %{decimal: true}) == Decimal.new("-0")
-    assert parse!("99", %{decimal: true}) == Decimal.new("99")
-    assert parse!("-99", %{decimal: true}) == Decimal.new("-99")
+    assert parse!("0", %{decimal: true}) == 0
+    assert parse!("-0", %{decimal: true}) == -0
+    assert parse!("99", %{decimal: true}) == 99
+    assert parse!("-99", %{decimal: true}) == -99
+
     assert parse!("99.99", %{decimal: true}) == Decimal.new("99.99")
     assert parse!("-99.99", %{decimal: true}) == Decimal.new("-99.99")
     assert parse!("99.99e99", %{decimal: true}) == Decimal.new("99.99e99")


### PR DESCRIPTION
It's unnecessary to decode them as `Decimal`s with `decimal: true`, since integers can already be of arbitrary size, limited only by memory.

It can create issues in controllers when the `Plug.Parsers` plug is configured to use Poison with the `:decimal` option:

```elixir
plug Plug.Parsers,
  parsers: [:urlencoded, :multipart, :json],
  pass: ["*/*"],
  json_decoder: {Poison, :decode!, [[decimal: true]]}
```