### PR TITLE
Handle ArgumentError from IO.iodata_to_binary in Parser.parse!/2

### DIFF
--- a/lib/poison/parser.ex
+++ b/lib/poison/parser.ex
@@ -98,6 +98,9 @@ defmodule Poison.Parser do
 
   def parse!(iodata, options) do
     iodata |> IO.iodata_to_binary() |> parse!(options)
+  rescue
+    ArgumentError ->
+      reraise %ParseError{value: iodata}, __STACKTRACE__
   end
 
   @compile {:inline, value: 5}

--- a/test/poison/parser_test.exs
+++ b/test/poison/parser_test.exs
@@ -298,6 +298,12 @@ defmodule Poison.ParserTest do
     end
   end
 
+  test "nil" do
+    assert_raise ParseError, "unexpected end of input at position 0", fn ->
+      parse!(nil)
+    end
+  end
+
   defp parse(iodata, options \\ %{}) do
     {:ok, parse!(iodata, options)}
   rescue


### PR DESCRIPTION
This will fix https://github.com/devinus/poison/issues/226

Result in iex
```
iex(1)> Poison.decode(nil)
{:error, %Poison.ParseError{data: "", skip: 0, value: nil}}
```